### PR TITLE
chore: add multi-arch support and OCI labels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,7 @@ WORKDIR /
 COPY --from=builder /bin/manager .
 USER nonroot:nonroot
 
+LABEL org.opencontainers.image.source=https://github.com/kitagry/berglas-secret-controller
+LABEL org.opencontainers.image.description="CustomController of k8s for berglas secret"
+
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
- Added multi-architecture support for Docker images in the GitHub Actions workflow (`.github/workflows/release.yaml`).
- Added OCI labels for source and description in the Dockerfile.